### PR TITLE
Fix UUID generation to generate a new UUID for every request

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "semantic-release": "^17.0.2",
     "semantic-release-cli": "5.2.3",
     "ts-node": "8.8.1",
-    "typescript": "3.8.3"
+    "typescript": "^4.1.2"
   },
   "engines": {
     "node": ">=10"

--- a/src/rest-adapter.ts
+++ b/src/rest-adapter.ts
@@ -48,9 +48,13 @@ export default class RESTAdapter<Name> {
       responseType: 'json',
       headers: {
         Authorization: `Bearer ${token}`,
-        'X-Request-Id': uuid(),
       },
       hooks: {
+        beforeRequest: [
+          (options): void => {
+            options.headers['X-Request-Id'] = uuid();
+          },
+        ],
         beforeError: [
           /* istanbul ignore next */
           (error: GeneralError): GeneralError => {


### PR DESCRIPTION
This API previously generated one UUID per client, which meant the UUID was cached across requests. (In my testing, it looks like 5 clients were constructed on initialization. I didn't dig into the code to see why.)

Sending a cached non-unique ID to Todoist results in errors: `Sync item already processed. Ignored.`. This PR changes the ID to be created for every request so it's guaranteed to be unique. :)